### PR TITLE
Use static class for serial port façade

### DIFF
--- a/Marlin/src/HAL/HAL_AVR/HAL_AVR.cpp
+++ b/Marlin/src/HAL/HAL_AVR/HAL_AVR.cpp
@@ -57,17 +57,7 @@
 
 //uint8_t MCUSR;
 
-#ifdef USBCON
-  #if ENABLED(BLUETOOTH)
-    SerialFacade<HardwareSerial> MYSERIAL0(bluetoothSerial);
-  #else
-    SerialFacade<HardwareSerial> MYSERIAL0(Serial);
-  #endif // BLUETOOTH
-#else
-  SerialFacade<MarlinSerial> MYSERIAL0(customizedSerial);
-#endif
-
-SerialFacadeBase* MYSERIAL[NUM_SERIAL] = { &MYSERIAL0 };
+SerialFacade<SERIAL0_CLASS> MYSERIAL0(SERIAL0_REF);
 
 // --------------------------------------------------------------------------
 // Private Variables

--- a/Marlin/src/HAL/HAL_AVR/HAL_AVR.h
+++ b/Marlin/src/HAL/HAL_AVR/HAL_AVR.h
@@ -87,7 +87,20 @@ typedef int8_t pin_t;
 //extern uint8_t MCUSR;
 
 #define NUM_SERIAL 1
-extern SerialFacadeBase* MYSERIAL[NUM_SERIAL]; 
+
+#ifdef USBCON
+  #define SERIAL0_CLASS HardwareSerial
+  #if ENABLED(BLUETOOTH)
+    #define SERIAL0_REF bluetoothSerial
+  #else
+    #define SERIAL0_REF Serial
+  #endif
+#else
+  #define SERIAL0_CLASS MarlinSerial
+  #define SERIAL0_REF customizedSerial
+#endif
+
+extern SerialFacade<SERIAL0_CLASS> MYSERIAL0;
 
 // --------------------------------------------------------------------------
 // Public functions

--- a/Marlin/src/HAL/HAL_DUE/HAL_Due.cpp
+++ b/Marlin/src/HAL/HAL_DUE/HAL_Due.cpp
@@ -57,22 +57,7 @@
 
 uint16_t HAL_adc_result;
 
-#undef SERIAL_PORT
-#define SERIAL_PORT -1
-
-#if SERIAL_PORT == -1
-  SerialFacade<Serial_> MYSERIAL0(SerialUSB);
-#elif SERIAL_PORT == 0
-  SerialFacade<MarlinSerial> MYSERIAL0(customizedSerial);
-#elif SERIAL_PORT == 1
-  SerialFacade<MarlinSerial> MYSERIAL0(customizedSerial);
-#elif SERIAL_PORT == 2
-  SerialFacade<MarlinSerial> MYSERIAL0(customizedSerial);
-#elif SERIAL_PORT == 3
-  SerialFacade<MarlinSerial> MYSERIAL0(customizedSerial);
-#endif
-
-SerialFacadeBase* MYSERIAL[NUM_SERIAL] = { &MYSERIAL0 };
+SerialFacade<SERIAL0_CLASS> MYSERIAL0(SERIAL0_REF);
 
 // --------------------------------------------------------------------------
 // Private Variables

--- a/Marlin/src/HAL/HAL_DUE/HAL_Due.h
+++ b/Marlin/src/HAL/HAL_DUE/HAL_Due.h
@@ -149,7 +149,19 @@ void HAL_enable_AdcFreerun(void);
  */
 
 #define NUM_SERIAL 1
-extern SerialFacadeBase* MYSERIAL[NUM_SERIAL]; 
+
+#undef SERIAL_PORT
+#define SERIAL_PORT -1
+
+#if SERIAL_PORT == -1
+  #define SERIAL0_CLASS Serial_
+  #define SERIAL0_REF SerialUSB
+#else
+  #define SERIAL0_CLASS MarlinSerial
+  #define SERIAL0_REF customizedSerial
+#endif
+
+extern SerialFacade<SERIAL0_CLASS> MYSERIAL0;
 
 /**
  * Pin Map

--- a/Marlin/src/HAL/HAL_LPC1768/HAL.cpp
+++ b/Marlin/src/HAL/HAL_LPC1768/HAL.cpp
@@ -29,38 +29,11 @@ extern "C" {
 
 HalSerial usb_serial;
 
-#if SERIAL_PORT == -1
-  SerialFacade<HalSerial> MYSERIAL0(usb_serial);
-#elif SERIAL_PORT == 0
-  SerialFacade<HardwareSerial> MYSERIAL0(Serial);
-#elif SERIAL_PORT == 1
-  SerialFacade<HardwareSerial> MYSERIAL0(Serial1);
-#elif SERIAL_PORT == 2
-  SerialFacade<HardwareSerial> MYSERIAL0(Serial2);
-#elif SERIAL_PORT == 3
-  SerialFacade<HardwareSerial> MYSERIAL0(Serial3);
-#endif
+SerialFacade<SERIAL0_CLASS> MYSERIAL0(SERIAL0_REF);
 
 #ifdef SECONDARY_SERIAL_PORT
-  #if SECONDARY_SERIAL_PORT == -1
-    SerialFacade<HalSerial> MYSERIAL1(usb_serial);
-  #elif SECONDARY_SERIAL_PORT == 0
-    SerialFacade<HardwareSerial> MYSERIAL1(Serial);
-  #elif SECONDARY_SERIAL_PORT == 1
-    SerialFacade<HardwareSerial> MYSERIAL1(Serial1);
-  #elif SECONDARY_SERIAL_PORT == 2
-    SerialFacade<HardwareSerial> MYSERIAL1(Serial2);
-  #elif SECONDARY_SERIAL_PORT == 3
-    SerialFacade<HardwareSerial> MYSERIAL1(Serial3);
-  #endif
+  SerialFacade<SERIAL1_CLASS> MYSERIAL1(SERIAL1_REF);
 #endif
-
-SerialFacadeBase* MYSERIAL[NUM_SERIAL] = {
-  &MYSERIAL0,
-  #ifdef SECONDARY_SERIAL_PORT
-    &MYSERIAL1
-  #endif
-};
 
 // U8glib required functions
 extern "C" void u8g_xMicroDelay(uint16_t val) {

--- a/Marlin/src/HAL/HAL_LPC1768/HAL.h
+++ b/Marlin/src/HAL/HAL_LPC1768/HAL.h
@@ -69,19 +69,50 @@ extern "C" volatile uint32_t _millis;
   #error "SERIAL_PORT must be from -1 to 3"
 #endif
 
+#if SERIAL_PORT == -1
+  #define SERIAL0_CLASS HalSerial
+  #define SERIAL0_REF usb_serial
+#else
+  #define SERIAL1_CLASS HardwareSerial
+  #if SERIAL_PORT == 0
+    #define SERIAL0_REF Serial
+  #elif SERIAL_PORT == 1
+    #define SERIAL0_REF Serial1
+  #elif SERIAL_PORT == 2
+    #define SERIAL0_REF Serial2
+  #elif SERIAL_PORT == 3
+    #define SERIAL0_REF Serial3
+  #endif
+#endif
+
+extern SerialFacade<SERIAL0_CLASS> MYSERIAL0;
+
 #ifdef SECONDARY_SERIAL_PORT
   #if !WITHIN(SECONDARY_SERIAL_PORT, -1, 3)
     #error "SECONDARY_SERIAL_PORT must be from -1 to 3"
   #elif SECONDARY_SERIAL_PORT == SERIAL_PORT
     #error "SECONDARY_SERIAL_PORT must be different than SERIAL_PORT"
   #endif
-
   #define NUM_SERIAL 2
+  #if SECONDARY_SERIAL_PORT == -1
+    #define SERIAL1_CLASS HalSerial
+    #define SERIAL1_REF usb_serial
+  #else
+    #define SERIAL1_CLASS HalSerial
+    #if SECONDARY_SERIAL_PORT == 0
+      #define SERIAL1_REF Serial
+    #elif SECONDARY_SERIAL_PORT == 1
+      #define SERIAL1_REF Serial1
+    #elif SECONDARY_SERIAL_PORT == 2
+      #define SERIAL1_REF Serial2
+    #elif SECONDARY_SERIAL_PORT == 3
+      #define SERIAL1_REF Serial3
+    #endif
+  #endif
+  extern SerialFacade<SERIAL1_CLASS> MYSERIAL1;
 #else
   #define NUM_SERIAL 1
 #endif
-
-extern SerialFacadeBase* MYSERIAL[NUM_SERIAL];
 
 #define CRITICAL_SECTION_START  uint32_t primask = __get_PRIMASK(); __disable_irq();
 #define CRITICAL_SECTION_END    if (!primask) __enable_irq();

--- a/Marlin/src/HAL/HAL_LPC1768/main.cpp
+++ b/Marlin/src/HAL/HAL_LPC1768/main.cpp
@@ -93,9 +93,14 @@ int main(void) {
     debug_frmwrk_init();
   #endif
 
-  for (int i = 0; i < NUM_SERIAL; ++i) MYSERIAL[i]->begin(BAUDRATE);
-  SERIAL_PRINTF("\n\nLPC1768 (%dMhz) UART0 Initialised\n", SystemCoreClock / 1000000);
-  SERIAL_FLUSHTX();
+  #if NUM_SERIAL > 0
+    MYSERIAL0.begin(BAUDRATE);
+    #if NUM_SERIAL > 1
+      MYSERIAL1.begin(BAUDRATE);
+    #endif
+    SERIAL_PRINTF("\n\nLPC1768 (%dMhz) UART0 Initialised\n", SystemCoreClock / 1000000);
+    SERIAL_FLUSHTX();
+  #endif
 
   HAL_timer_init();
 

--- a/Marlin/src/HAL/HAL_TEENSY35_36/HAL_Teensy.cpp
+++ b/Marlin/src/HAL/HAL_TEENSY35_36/HAL_Teensy.cpp
@@ -94,18 +94,6 @@ void HAL_adc_start_conversion(const uint8_t adc_pin) { ADC0_SC1A = pin2sc1a[adc_
 
 uint16_t HAL_adc_get_result(void) { return ADC0_RA; }
 
-#if SERIAL_PORT == -1
-  SerialFacade<usb_serial_class> MYSERIAL0(SerialUSB);
-#elif SERIAL_PORT == 0
-  SerialFacade<usb_serial_class> MYSERIAL0(Serial);
-#elif SERIAL_PORT == 1
-  SerialFacade<HardwareSerial> MYSERIAL0(Serial1);
-#elif SERIAL_PORT == 2
-  SerialFacade<HardwareSerial> MYSERIAL0(Serial2);
-#elif SERIAL_PORT == 3
-  SerialFacade<HardwareSerial> MYSERIAL0(Serial3);
-#endif
-
-SerialFacadeBase* MYSERIAL[NUM_SERIAL] = { &MYSERIAL0 };
+SerialFacade<SERIAL0_CLASS> MYSERIAL0(SERIAL0_REF);
 
 #endif // __MK64FX512__ || __MK66FX1M0__

--- a/Marlin/src/HAL/HAL_TEENSY35_36/HAL_Teensy.h
+++ b/Marlin/src/HAL/HAL_TEENSY35_36/HAL_Teensy.h
@@ -131,7 +131,27 @@ uint16_t HAL_adc_get_result(void);
 */
 
 #define NUM_SERIAL 1
-extern SerialFacadeBase* MYSERIAL[NUM_SERIAL]; 
+
+#if SERIAL_PORT == -1
+  #define SERIAL0_CLASS usb_serial_class
+  #define SERIAL0_REF SerialUSB
+#else
+  #if SERIAL_PORT == 0
+    #define SERIAL0_CLASS usb_serial_class
+    #define SERIAL0_REF Serial
+  #else
+    #define SERIAL0_CLASS HardwareSerial
+    #if SERIAL_PORT == 1
+      #define SERIAL0_REF Serial1
+    #elif SERIAL_PORT == 2
+      #define SERIAL0_REF Serial2
+    #elif SERIAL_PORT == 3
+      #define SERIAL0_REF Serial3
+    #endif
+  #endif
+#endif
+
+extern SerialFacade<SERIAL0_CLASS> MYSERIAL0;
 
 #define GET_PIN_MAP_PIN(index) index
 #define GET_PIN_MAP_INDEX(pin) pin

--- a/Marlin/src/HAL/SerialFacade.h
+++ b/Marlin/src/HAL/SerialFacade.h
@@ -27,19 +27,49 @@
 #ifndef _SERIALFACADE_H_
 #define _SERIALFACADE_H_
 
-class SerialFacadeBase {
-public:
-  virtual void begin(uint32_t baudrate) = 0;
-  virtual int peek() = 0;
-  virtual int read() = 0;
-  virtual void write(uint8_t send) = 0;
-  #if TX_BUFFER_SIZE > 0
-    virtual void flushTX() = 0;
-  #endif
-  virtual int available() = 0;
-  virtual void flush() = 0;
+#include "../core/macros.h"
 
-  virtual void printf(const char *format, ...) {
+template <typename T> class SerialFacade {
+private:
+  static T& serial;
+
+public:
+  SerialFacade(T& serial) : serial(serial) {}
+
+  static inline operator bool()                                         { return !!serial; }
+
+  static FORCE_INLINE void begin(uint32_t baudrate)                     { serial.begin(baudrate); }
+  static FORCE_INLINE int peek()                                        { return serial.peek(); }
+  static FORCE_INLINE int read()                                        { return serial.read(); }
+  static FORCE_INLINE void write(uint8_t send)                          { serial.write(send); }
+  #if TX_BUFFER_SIZE > 0
+    static FORCE_INLINE void flushTX()                                  { serial.flushTX(); }
+  #endif
+  static FORCE_INLINE int available()                                   { return serial.available(); }
+  static FORCE_INLINE void flush()                                      { serial.flush(); }
+
+  static FORCE_INLINE void print(const char value[])                    { serial.print(value); }
+  static FORCE_INLINE void print(char value, int base = 0)              { serial.print(value, base); }
+  static FORCE_INLINE void print(unsigned char value, int base = 0)     { serial.print(value, base); }
+  static FORCE_INLINE void print(int value, int base = 10)              { serial.print(value, base); }
+  static FORCE_INLINE void print(unsigned int value, int base = 10)     { serial.print(value, base); }
+  static FORCE_INLINE void print(long value, int base = 10)             { serial.print(value, base); }
+  static FORCE_INLINE void print(unsigned long value, int base = 10)    { serial.print(value, base); }
+  static FORCE_INLINE void print(float value, int round = 2)            { serial.print(value, round); }
+  static FORCE_INLINE void print(double value, int round = 2)           { serial.print(value, round); }
+
+  static FORCE_INLINE void println(const char value[])                  { serial.println(value); }
+  static FORCE_INLINE void println(char value, int base = 0)            { serial.println(value, base); }
+  static FORCE_INLINE void println(unsigned char value, int base = 0)   { serial.println(value, base); }
+  static FORCE_INLINE void println(int value, int base = 10)            { serial.println(value, base); }
+  static FORCE_INLINE void println(unsigned int value, int base = 10)   { serial.println(value, base); }
+  static FORCE_INLINE void println(long value, int base = 10)           { serial.println(value, base); }
+  static FORCE_INLINE void println(unsigned long value, int base = 10)  { serial.println(value, base); }
+  static FORCE_INLINE void println(float value, int round = 2)          { serial.println(value, round); }
+  static FORCE_INLINE void println(double value, int round = 2)         { serial.println(value, round); }
+  static FORCE_INLINE void println(void)                                { serial.println(); }
+
+  static inline void printf(const char *format, ...) {
     char RxBuffer[256];
     va_list vArgs;
     va_start(vArgs, format);
@@ -51,71 +81,6 @@ public:
     }
   }
 
-  virtual operator bool() = 0;
-
-  virtual void print(const char value[]) = 0;
-  virtual void print(char value, int base = 0) = 0;
-  virtual void print(unsigned char value, int base = 0) = 0;
-  virtual void print(int value, int base = 10) = 0;
-  virtual void print(unsigned int value, int base = 10) = 0;
-  virtual void print(long value, int base = 10) = 0;
-  virtual void print(unsigned long value, int base = 10) = 0;
-
-  virtual void print(float value, int round = 2) = 0;
-  virtual void print(double value, int round = 2) = 0;
-
-  virtual void println(const char value[]) = 0;
-  virtual void println(char value, int base = 0) = 0;
-  virtual void println(unsigned char value, int base = 0) = 0;
-  virtual void println(int value, int base = 10) = 0;
-  virtual void println(unsigned int value, int base = 10) = 0;
-  virtual void println(long value, int base = 10) = 0;
-  virtual void println(unsigned long value, int base = 10) = 0;
-  virtual void println(float value, int round = 2) = 0;
-  virtual void println(double value, int round = 2) = 0;
-  virtual void println(void) = 0;
-};
-
-template <typename T> class SerialFacade : public SerialFacadeBase {
-private:
-  T& serial;
-
-public:
-  SerialFacade(T& serial) : serial(serial)                 {}
-
-  virtual void begin(uint32_t baudrate)                     { serial.begin(baudrate); }
-  virtual int peek()                                        { return serial.peek(); }
-  virtual int read()                                        { return serial.read(); }
-  void write(uint8_t send)                                  { serial.write(send); }
-  #if TX_BUFFER_SIZE > 0
-    virtual void flushTX()                                  { serial.flushTX(); }
-  #endif
-  virtual int available()                                   { return serial.available(); }
-  virtual void flush()                                      { serial.flush(); }
-
-  virtual operator bool()                                   { return serial ? true : false; }
-
-  virtual void print(const char value[])                    { serial.print(value); }
-  virtual void print(char value, int base = 0)              { serial.print(value, base); }
-  virtual void print(unsigned char value, int base = 0)     { serial.print(value, base); }
-  virtual void print(int value, int base = 10)              { serial.print(value, base); }
-  virtual void print(unsigned int value, int base = 10)     { serial.print(value, base); }
-  virtual void print(long value, int base = 10)             { serial.print(value, base); }
-  virtual void print(unsigned long value, int base = 10)    { serial.print(value, base); }
-
-  virtual void print(float value, int round = 2)            { serial.print(value, round); }
-  virtual void print(double value, int round = 2)           { serial.print(value, round); }
-
-  virtual void println(const char value[])                  { serial.println(value); }
-  virtual void println(char value, int base = 0)            { serial.println(value, base); }
-  virtual void println(unsigned char value, int base = 0)   { serial.println(value, base); }
-  virtual void println(int value, int base = 10)            { serial.println(value, base); }
-  virtual void println(unsigned int value, int base = 10)   { serial.println(value, base); }
-  virtual void println(long value, int base = 10)           { serial.println(value, base); }
-  virtual void println(unsigned long value, int base = 10)  { serial.println(value, base); }
-  virtual void println(float value, int round = 2)          { serial.println(value, round); }
-  virtual void println(double value, int round = 2)         { serial.println(value, round); }
-  virtual void println(void)                                { serial.println(); }
 };
 
 #endif // _SERIALFACADE_H_

--- a/Marlin/src/Marlin.cpp
+++ b/Marlin/src/Marlin.cpp
@@ -675,13 +675,21 @@ void setup() {
     disableStepperDrivers();
   #endif
 
-  for (uint8_t i = 0; i < NUM_SERIAL; ++i)
-    MYSERIAL[i]->begin(BAUDRATE);
+  #if NUM_SERIAL > 0
+    MYSERIAL0.begin(BAUDRATE);
+    #if NUM_SERIAL > 1
+      MYSERIAL(1).begin(BAUDRATE);
+    #endif
+  #endif
 
-  for (uint8_t i = 0; i < NUM_SERIAL; ++i) {
-    const uint32_t serial_connect_timeout = millis() + 1000UL;
-    while(!MYSERIAL[i] && PENDING(millis(), serial_connect_timeout)) { /*nada*/ }
-  }
+  #if NUM_SERIAL > 0
+    uint32_t serial_connect_timeout = millis() + 1000UL;
+    while(!MYSERIAL0 && PENDING(millis(), serial_connect_timeout)) { /*nada*/ }
+    #if NUM_SERIAL > 1
+      serial_connect_timeout = millis() + 1000UL;
+      while(!MYSERIAL(1) && PENDING(millis(), serial_connect_timeout)) { /*nada*/ }
+    #endif
+  #endif
 
   SERIAL_PROTOCOLLNPGM("start");
   SERIAL_ECHO_START();

--- a/Marlin/src/core/serial.h
+++ b/Marlin/src/core/serial.h
@@ -55,14 +55,33 @@ extern uint8_t marlin_debug_flags;
 extern const char echomagic[] PROGMEM;
 extern const char errormagic[] PROGMEM;
 
-#define SERIAL_CHAR(x) do { for(int i = 0; i < NUM_SERIAL; ++i) MYSERIAL[i]->write(x); } while(0)
+#if TX_BUFFER_SIZE < 1
+  #define SERIAL_FLUSHTX()
+#endif
+
+#ifdef SECONDARY_SERIAL_PORT
+  #define SERIAL_CHAR(x)              do{ MYSERIAL0.write(x); MYSERIAL1.write(x); }while(0)
+  #define SERIAL_PROTOCOL(x)          do{ MYSERIAL0.print(x); MYSERIAL1.print(x); }while(0)
+  #define SERIAL_PROTOCOL_F(x,y)      do{ MYSERIAL0.print(x,y); MYSERIAL1.print(x,y); }while(0)
+  #define SERIAL_PROTOCOLLN(x)        do{ MYSERIAL0.println(x); MYSERIAL1.println(x); }while(0)
+  #define SERIAL_PRINTF(fmt, args...) do{ MYSERIAL0.printf(fmt, args); MYSERIAL1.printf(fmt, args); }while(0)
+  #if TX_BUFFER_SIZE > 0
+    #define SERIAL_FLUSHTX()          do{ MYSERIAL0.flushTX(); MYSERIAL1.flushTX(); }while(0)
+  #endif
+#else
+  #define SERIAL_CHAR(x)              MYSERIAL0.write(x)
+  #define SERIAL_PROTOCOL(x)          MYSERIAL0.print(x);
+  #define SERIAL_PROTOCOL_F(x,y)      MYSERIAL0.print(x,y);
+  #define SERIAL_PROTOCOLLN(x)        MYSERIAL0.println(x);
+  #define SERIAL_PRINTF(fmt, args...) MYSERIAL0.printf(fmt, args);
+  #if TX_BUFFER_SIZE > 0
+    #define SERIAL_FLUSHTX()          MYSERIAL0.flushTX();
+  #endif
+#endif
 #define SERIAL_EOL() SERIAL_CHAR('\n')
 
 #define SERIAL_PROTOCOLCHAR(x)              SERIAL_CHAR(x)
-#define SERIAL_PROTOCOL(x)                  do { for(int i = 0; i < NUM_SERIAL; ++i) MYSERIAL[i]->print(x); } while(0)
-#define SERIAL_PROTOCOL_F(x,y)              do { for(int i = 0; i < NUM_SERIAL; ++i) MYSERIAL[i]->print(x,y); } while(0)
 #define SERIAL_PROTOCOLPGM(x)               (serialprintPGM(PSTR(x)))
-#define SERIAL_PROTOCOLLN(x)                do { for(int i = 0; i < NUM_SERIAL; ++i) MYSERIAL[i]->println(x); } while(0)
 #define SERIAL_PROTOCOLLNPGM(x)             (serialprintPGM(PSTR(x "\n")))
 #define SERIAL_PROTOCOLPAIR(pre, value)     (serial_echopair_P(PSTR(pre),(value)))
 #define SERIAL_PROTOCOLLNPAIR(pre, value)   do { SERIAL_PROTOCOLPAIR(pre, value); SERIAL_EOL(); } while(0)
@@ -104,14 +123,6 @@ void serial_spaces(uint8_t count);
 #define SERIAL_ECHO_SP(C)     serial_spaces(C)
 #define SERIAL_ERROR_SP(C)    serial_spaces(C)
 #define SERIAL_PROTOCOL_SP(C) serial_spaces(C)
-
-#define SERIAL_PRINTF(fmt, args...) do { for(int i = 0; i < NUM_SERIAL; ++i) MYSERIAL[i]->printf(fmt, args); } while(0)
-
-#if TX_BUFFER_SIZE > 0
-  #define SERIAL_FLUSHTX() do { for(int i = 0; i < NUM_SERIAL; ++i) MYSERIAL[i]->flushTX(); } while(0)
-#else
-  #define SERIAL_FLUSHTX()
-#endif
 
 //
 // Functions for serial printing from PROGMEM. (Saves loads of SRAM.)

--- a/Marlin/src/gcode/queue.cpp
+++ b/Marlin/src/gcode/queue.cpp
@@ -183,7 +183,7 @@ void ok_to_send() {
  */
 void flush_and_request_resend() {
   //char command_queue[cmd_queue_index_r][100]="Resend:";
-  MYSERIAL[0]->flush();
+  MYSERIAL0.flush();
   SERIAL_PROTOCOLPGM(MSG_RESEND);
   SERIAL_PROTOCOLLN(gcode_LastN + 1);
   ok_to_send();
@@ -212,7 +212,7 @@ inline void get_serial_commands() {
   #if defined(NO_TIMEOUTS) && NO_TIMEOUTS > 0
     static millis_t last_command_time = 0;
     const millis_t ms = millis();
-    if (commands_in_queue == 0 && !MYSERIAL[0]->available() && ELAPSED(ms, last_command_time + NO_TIMEOUTS)) {
+    if (commands_in_queue == 0 && !MYSERIAL0.available() && ELAPSED(ms, last_command_time + NO_TIMEOUTS)) {
       SERIAL_ECHOLNPGM(MSG_WAIT);
       last_command_time = ms;
     }
@@ -222,7 +222,7 @@ inline void get_serial_commands() {
    * Loop while serial characters are incoming and the queue is not full
    */
   int c;
-  while (commands_in_queue < BUFSIZE && (c = MYSERIAL[0]->read()) >= 0) {
+  while (commands_in_queue < BUFSIZE && (c = MYSERIAL0.read()) >= 0) {
     char serial_char = c;
 
     /**
@@ -324,7 +324,7 @@ inline void get_serial_commands() {
     }
     else if (serial_char == '\\') {  // Handle escapes
       // if we have one more character, copy it over
-      if ((c = MYSERIAL[0]->read()) >= 0 && !serial_comment_mode)
+      if ((c = MYSERIAL0.read()) >= 0 && !serial_comment_mode)
         serial_line_buffer[serial_count++] = serial_char;
     }
     else { // it's not a newline, carriage return or escape char


### PR DESCRIPTION
This is what using static classes will look like. I haven't compiled it, but I expect the `SerialFacade` items in `HAL.h` to conflict with the platform-specific `HAL_xxx.h` headers. That shouldn't be hard to sort out.

Anyway, as you can see this doesn't make things too messy (same number of lines too), and should compile to smaller code than the current non-`static` implementation.